### PR TITLE
feat: polycon inheritance with explicit "concretize-able classes"

### DIFF
--- a/API.md
+++ b/API.md
@@ -69,7 +69,6 @@ Returns a string representation of this construct.
 | --- | --- |
 | <code><a href="#@monadahq/polycons.Polycon.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
 | <code><a href="#@monadahq/polycons.Polycon.concretize">concretize</a></code> | Invoke this method on the class you wish to use as an implementation of a polycon. |
-| <code><a href="#@monadahq/polycons.Polycon.isPolycon">isPolycon</a></code> | Checks if `x` is a polycon. |
 | <code><a href="#@monadahq/polycons.Polycon.isPolyconClass">isPolyconClass</a></code> | Checks if `x` is a polycon-based class that should be considered abstract. |
 
 ---
@@ -103,24 +102,6 @@ Polycon.concretize()
 Invoke this method on the class you wish to use as an implementation of a polycon.
 
 Note: Do not call this with `Polycon`, use a subclass of `Polycon` instead.
-
-##### `isPolycon` <a name="isPolycon" id="@monadahq/polycons.Polycon.isPolycon"></a>
-
-```typescript
-import { Polycon } from '@monadahq/polycons'
-
-Polycon.isPolycon(x: any)
-```
-
-Checks if `x` is a polycon.
-
-###### `x`<sup>Required</sup> <a name="x" id="@monadahq/polycons.Polycon.isPolycon.parameter.x"></a>
-
-- *Type:* any
-
-Any object.
-
----
 
 ##### `isPolyconClass` <a name="isPolyconClass" id="@monadahq/polycons.Polycon.isPolyconClass"></a>
 

--- a/src/polycon.ts
+++ b/src/polycon.ts
@@ -1,7 +1,6 @@
 import { Construct } from "constructs";
 import { PolyconFactory } from "./polycon-factory";
 
-const POLYCON_SYMBOL = Symbol.for("polycons.Polycon");
 const POLYCON_CLASS_SYMBOL = Symbol.for("polycons.PolyconClass");
 
 /**
@@ -9,15 +8,6 @@ const POLYCON_CLASS_SYMBOL = Symbol.for("polycons.PolyconClass");
  * specific construct.
  */
 export abstract class Polycon extends Construct {
-  /**
-   * Checks if `x` is a polycon.
-   * @returns true if `x` is an object created from a class which extends `Polycon`.
-   * @param x Any object
-   */
-  public static isPolycon(x: any): x is Polycon {
-    return x && typeof x === "object" && x[POLYCON_SYMBOL];
-  }
-
   /**
    * Checks if `x` is a polycon-based class that should be considered abstract.
    * @returns true if `x` is a class that extends `Polycon` and is not allowed to be constructed directly.

--- a/test/polycon.test.ts
+++ b/test/polycon.test.ts
@@ -1,22 +1,12 @@
 import { Construct, IConstruct } from "constructs";
 import { Polycon, PolyconFactory } from "../src";
 
-test("can construct concrete polycons directly", () => {
+test("a concrete polycon can be constructed directly", () => {
   const app = new App();
   const dog = new Poodle(app, "dog", { name: "piffle", treats: 5 });
 
-  expect(Polycon.isPolycon(dog)).toBeFalsy();
+  expect(dog instanceof Construct).toBeTruthy();
   expect(Polycon.isPolyconClass(Poodle)).toBeFalsy();
-});
-
-test("Polycon.isPolycon returns true for polycons", () => {
-  const app = new App();
-  PolyconFactory.register(app, new PoodleFactory());
-  const dog = new Dog(app, "dog", { name: "piffle", treats: 5 });
-
-  expect(Polycon.isPolycon(dog)).toBeTruthy();
-  expect(Polycon.isPolycon(app)).toBeFalsy();
-  expect(Polycon.isPolyconClass(Dog)).toBeTruthy();
 });
 
 // this is important for languages that use nominal typing (like Java)


### PR DESCRIPTION
Yet another approach for polycons to allow inheritance 😄 
This was aimed at ensuring that the actual implementation classes are able to be constructed directly.

The approach used here allows users to mark certain classes as "concrete", showing that they are not polycons but rather an implementation. With this knowledge explicitly known, we can avoid the recursive-resolving issue while still allowing direct constructor usage.

The obvious downside here is that the syntax for marking a class,

```ts
// Polycon
class Dog extends Polycon { ... }

// Implementation
class Poodle extends Dog { ... }
Poodle.concretize();
```

is pretty obtuse/magical. Normally this would be a perfect use case for a decorator, but that's not an option here. 
Another issue is if one forgets to add this when appropriate, it will be possible to hit the infinite recursion again.